### PR TITLE
set lock class when lockBody is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ class App extends Component {
 }
 ```
 
+You can set the `lockBody` property to `true` to add the `zvui_teleport-lock` class to the body.
+Then in your App you can set `overflow: hidden` to that class in order to prevent body scrolling.
+
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class App extends Component {
 ```
 
 You can set the `lockBody` property to `true` to add the `zvui_teleport-lock` class to the body.
-Then in your App you can set `overflow: hidden` to that class in order to prevent body scrolling.
+Scroll position and body properties to block scroll will be handled automatically
 
 
 ## Dependencies

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-teleport-me",
   "moduleName": "Teleport",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "React component to teleport component render to body.",
   "main": "build/react-teleport-me",
   "browser": "build/react-teleport-me",

--- a/src/Teleport.jsx
+++ b/src/Teleport.jsx
@@ -42,7 +42,7 @@ class Teleport extends Component {
     componentWillUnmount = () => {
         this._unrenderOverlay();
         this._unmountOverlayTarget();
-        this._unlockBody();
+        if (this.props.lockBody) this._unlockBody();
     };
 
     _lockBody() {

--- a/src/Teleport.jsx
+++ b/src/Teleport.jsx
@@ -18,11 +18,12 @@ class Teleport extends Component {
     };
 
     static defaultProps = {
-        lockBody: true,
+        lockBody: false,
         className: '',
     };
 
     componentDidMount = () => {
+        if (this.props.lockBody) this._lockBody();
         this._renderOverlay();
     };
 
@@ -41,7 +42,16 @@ class Teleport extends Component {
     componentWillUnmount = () => {
         this._unrenderOverlay();
         this._unmountOverlayTarget();
+        this._unlockBody();
     };
+
+    _lockBody() {
+        window.document.body.classList.add(`${BASE_CLASS}_teleport-lock`)
+    }
+
+    _unlockBody() {
+        window.document.body.classList.remove(`${BASE_CLASS}_teleport-lock`)
+    }
 
     _renderOverlay = () => {
         const overlay = !this.props.children ? null : React.Children.only(this.props.children);

--- a/src/Teleport.jsx
+++ b/src/Teleport.jsx
@@ -46,11 +46,19 @@ class Teleport extends Component {
     };
 
     _lockBody() {
-        window.document.body.classList.add(`${BASE_CLASS}_teleport-lock`)
+        this._scrollPosition = window.scrollY;
+        window.document.body.style.position = 'fixed';
+        window.document.body.style.width = '100vw';
+        window.document.body.style['margin-top'] = `-${this._scrollPosition}px`;
+        window.document.body.classList.add(`${BASE_CLASS}_teleport-lock`);
     }
 
     _unlockBody() {
-        window.document.body.classList.remove(`${BASE_CLASS}_teleport-lock`)
+        window.document.body.style.position = 'initial';
+        window.document.body.style.width = 'initial';
+        window.document.body.style['margin-top'] = 'initial';
+        window.scrollTo(0, this._scrollPosition);
+        window.document.body.classList.remove(`${BASE_CLASS}_teleport-lock`);
     }
 
     _renderOverlay = () => {


### PR DESCRIPTION
- basic functionality to set a lock class in the body

current limitations:
- to avoid shipping a one-line css is up to the consumer to define overflow hidden in the lock class
- as a quick initial implementation it will not play well with multiple teleports with lockbody true, in the future we can keep a global counter to decide if unlock or not.